### PR TITLE
Fix the issue of 'ChatCompletionRespone object has no attribute model…

### DIFF
--- a/openai_api.py
+++ b/openai_api.py
@@ -427,7 +427,7 @@ async def predict(
     chunk = ChatCompletionResponse(
         model=model_id, choices=[choice_data], object="chat.completion.chunk"
     )
-    yield "{}".format(chunk.model_dump_json(exclude_unset=True))
+    yield "{}".format(chunk.json(exclude_unset=True))
 
     current_length = 0
     stop_words_ids = [tokenizer.encode(s) for s in stop_words] if stop_words else None
@@ -453,7 +453,7 @@ async def predict(
         chunk = ChatCompletionResponse(
             model=model_id, choices=[choice_data], object="chat.completion.chunk"
         )
-        yield "{}".format(chunk.model_dump_json(exclude_unset=True))
+        yield "{}".format(chunk.json(exclude_unset=True))
 
     choice_data = ChatCompletionResponseStreamChoice(
         index=0, delta=DeltaMessage(), finish_reason="stop"
@@ -461,7 +461,7 @@ async def predict(
     chunk = ChatCompletionResponse(
         model=model_id, choices=[choice_data], object="chat.completion.chunk"
     )
-    yield "{}".format(chunk.model_dump_json(exclude_unset=True))
+    yield "{}".format(chunk.json(exclude_unset=True))
     yield "[DONE]"
 
     _gc()


### PR DESCRIPTION
# Reproduction Steps
After running openai.py, an exception occurs when requesting the `/v1/chat/completions` endpoint. The exception is as follows:
```bash
...
  File "/opt/conda/lib/python3.10/site-packages/starlette/routing.py", line 69, in app
    await response(scope, receive, send)
  File "/opt/conda/lib/python3.10/site-packages/sse_starlette/sse.py", line 233, in __call__
    async with anyio.create_task_group() as task_group:
  File "/opt/conda/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 597, in __aexit__
    raise exceptions[0]
  File "/opt/conda/lib/python3.10/site-packages/sse_starlette/sse.py", line 236, in wrap
    await func()
  File "/opt/conda/lib/python3.10/site-packages/sse_starlette/sse.py", line 221, in stream_response
    async for data in self.body_iterator:
  File "/app/Qwen/openai_api.py", line 430, in predict
    yield "{}".format(chunk.model_dump_json(exclude_unset=True))
AttributeError: 'ChatCompletionResponse' object has no attribute 'model_dump_json'
```

Request method is as follows:
```bash
curl -X POST -H "Content-Type: application/json" \
-H "Authorization: Bearer none" \
-d '{
  "model": "Qwen",
  "messages": [
    {"role": "user", "content": "你好"}
  ],
  "stream": true,
  "stop": []
}' \
http://127.0.0.18000/v1/chat/completions
```

# Fix Description
Upon examining the `model_dump_json` method in the `openai.py` code, it was found to be using the `FastAPI` framework.

The framework has a `json` method instead of `model_dump_json`. After changing the `model_dump_json` method to `json` method, the request was reproduced without any exception.