### PR TITLE
fix(finetune_ds.sh): `zero3` conflict with `device_map`

### DIFF
--- a/finetune/finetune_ds.sh
+++ b/finetune/finetune_ds.sh
@@ -72,4 +72,4 @@ torchrun $DISTRIBUTED_ARGS finetune.py \
     --model_max_length 512 \
     --gradient_checkpointing True \
     --lazy_preprocess True \
-    --deepspeed finetune/ds_config_zero3.json
+    --deepspeed finetune/ds_config_zero2.json


### PR DESCRIPTION
`huggingface/transformers`  v4.30.0-最新版，都有这么一段:

```bash
        if device_map is not None:
            if low_cpu_mem_usage is None:
                low_cpu_mem_usage = True
..
        if low_cpu_mem_usage:
..
            if is_deepspeed_zero3_enabled():
                raise ValueError(
                    "DeepSpeed Zero-3 is not compatible with `low_cpu_mem_usage=True` or with passing a `device_map`."
                )
```

https://github.com/huggingface/transformers/blob/a7cab3c283312b8d4de5df3bbe719971e24f4281/src/transformers/modeling_utils.py#L2847C1-L2861C18

导致 finetune 加载模型时 `model = transformers.AutoModelForCausalLM.from_pretrained` 会崩溃。
提示 `low_cpu_mem_usage` 和 deepspeed_zero3 冲突。

```bash
│ /root/miniconda3/envs/torch2/lib/python3.10/site-packages/transformers/modeling_utils.py:2364 in │
│ from_pretrained                                                                                  │
 ..
│   2363 │   │   │   if is_deepspeed_zero3_enabled():                                              │
│ ❱ 2364 │   │   │   │   raise ValueError(                                                         │
│   2365 │   │   │   │   │   "DeepSpeed Zero-3 is not compatible with `low_cpu_mem_usage=True` or  │
│   2366 │   │   │   │   )                                                                         │
│   2367 │   │   │   elif not is_accelerate_available():                                           │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
ValueError: DeepSpeed Zero-3 is not compatible with `low_cpu_mem_usage=True` or with passing a `device_map`.
```

无奈 qaq 
